### PR TITLE
fix(theme): stop upscaling content images to full column width

### DIFF
--- a/test/block-theme.test.js
+++ b/test/block-theme.test.js
@@ -1246,6 +1246,17 @@ describe("DocsPress block theme constraints", () => {
     }
   });
 
+  it("keeps content images at their intrinsic size instead of upscaling them", async () => {
+    const styles = await fs.readFile(path.join(root, "theme", "style.css"), "utf8");
+    const figureImageRule =
+      styles.match(/\n\.entry-content \.wp-block-image img\s*\{([^}]*)\}/)?.[1] ?? "";
+    const imageRule = styles.match(/\n\.entry-content img\s*\{([^}]*)\}/)?.[1] ?? "";
+
+    expect(figureImageRule).not.toMatch(/(?:^|\s)width\s*:/);
+    expect(imageRule).toMatch(/max-width:\s*100%;/);
+    expect(imageRule).toMatch(/height:\s*auto;/);
+  });
+
   it("lets Global Styles flow through the homepage shell and custom blocks", async () => {
     const theme = JSON.parse(await fs.readFile(path.join(root, "theme", "theme.json"), "utf8"));
     const styles = await fs.readFile(path.join(root, "theme", "style.css"), "utf8");

--- a/theme/style.css
+++ b/theme/style.css
@@ -1380,7 +1380,6 @@ body.command-search-open {
 
 .entry-content .wp-block-image img {
 	display: block;
-	width: 100%;
 	border: 1px solid var(--dp-line);
 	box-shadow: 0 10px 28px color-mix(in srgb, var(--dp-ink) 8%, transparent);
 }


### PR DESCRIPTION
## What

`theme/style.css` sets `width: 100%` on `.entry-content .wp-block-image img`. That forces every standalone image on a doc page up to the full content column, whatever its real size.

Markdown images land in that selector easily. `renderParagraph` in `src/markdown.js` turns any paragraph whose only child is an image into a `core/image` block, and `imageBlock` in `src/gutenberg.js` emits `<figure class="wp-block-image"><img …>` with no width or height attributes. So a 24px status badge, a small logo, or an icon written on its own line gets stretched to the full column, blurred, and wrapped in a border and a drop shadow.

It also cancels the float helpers. `.alignleft` and `.alignright` place the figure beside the text, but the child image is still 100% wide, so nothing wraps around it.

## The fix

Deleting that one declaration is enough. The generic `.entry-content img` rule right above already carries `max-width: 100%` and `height: auto`, which is what keeps images from overflowing. `width: 100%` only added the upscaling on top.

I deliberately did not replace it with `width: auto`. That would override the `width` attribute WordPress writes for resized images, and intrinsic sizing is already correct once the forced width is gone. Border, radius and shadow are untouched.

## Verification

New test in `test/block-theme.test.js` reads the `.entry-content .wp-block-image img` rule and asserts it declares no `width`, plus checks the generic image rule still has `max-width: 100%` and `height: auto`. It matches that specific rule rather than scanning the whole file, since other `width: 100%` declarations in the stylesheet are legitimate.

- `npx vitest run test/block-theme.test.js -t "intrinsic size"` fails against unpatched `style.css`, passes with the change.
- `npm test`: 132 passed.
- `npx eslint .`: clean.
