### PR TITLE
feat(theme): consolidate interactive cursors into one base layer

### DIFF
--- a/test/block-theme.test.js
+++ b/test/block-theme.test.js
@@ -1246,6 +1246,51 @@ describe("DocsPress block theme constraints", () => {
     }
   });
 
+  it("resolves interactive cursors from one base layer instead of per component", async () => {
+    const styles = await fs.readFile(path.join(root, "theme", "style.css"), "utf8");
+    const rule = (selector) => {
+      const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return styles.match(new RegExp(`\\n${escaped}\\s*\\{([^}]*)\\}`, "m"))?.[1] ?? "";
+    };
+
+    expect(rule("body")).toMatch(/cursor:\s*default;/);
+    expect(
+      rule(`a,
+button,
+summary,
+[role="button"],
+input[type="button"],
+input[type="checkbox"],
+input[type="radio"],
+input[type="submit"]`)
+    ).toMatch(/cursor:\s*pointer;/);
+    expect(
+      rule(`input,
+textarea,
+[contenteditable="true"]`)
+    ).toMatch(/cursor:\s*text;/);
+    expect(
+      rule(`a,
+button,
+[role="button"]`)
+    ).toMatch(/touch-action:\s*manipulation;/);
+
+    // Disabled-looking states still opt out, and .drawer-scrim is a div the base layer
+    // cannot reach.
+    expect(rule(".docs-nav.is-filtering .docs-nav-toggle")).toMatch(/cursor:\s*default;/);
+    expect(styles).toMatch(/\.drawer-scrim\s*\{[^}]*cursor:\s*pointer;/);
+
+    for (const selector of [
+      ".command-search-close",
+      ".copy-code",
+      ".docs-nav-toggle",
+      ".sidebar-collapse-toggle",
+      ".sidebar-search-clear",
+    ]) {
+      expect(rule(selector)).not.toMatch(/cursor:\s*pointer;/);
+    }
+  });
+
   it("lets Global Styles flow through the homepage shell and custom blocks", async () => {
     const theme = JSON.parse(await fs.readFile(path.join(root, "theme", "theme.json"), "utf8"));
     const styles = await fs.readFile(path.join(root, "theme", "style.css"), "utf8");

--- a/theme/style.css
+++ b/theme/style.css
@@ -146,6 +146,7 @@ body {
 	margin: 0;
 	overflow-x: clip;
 	-webkit-font-smoothing: antialiased;
+	cursor: default;
 }
 
 body.drawer-open {
@@ -167,9 +168,32 @@ select {
 	font: inherit;
 }
 
+a,
+button,
+summary,
+[role="button"],
+input[type="button"],
+input[type="checkbox"],
+input[type="radio"],
+input[type="submit"] {
+	cursor: pointer;
+}
+
+input,
+textarea,
+[contenteditable="true"] {
+	cursor: text;
+}
+
 button,
 a {
 	-webkit-tap-highlight-color: transparent;
+}
+
+a,
+button,
+[role="button"] {
+	touch-action: manipulation;
 }
 
 :focus-visible {
@@ -346,7 +370,6 @@ a {
 	border-radius: 8px;
 	background: var(--dp-canvas);
 	color: var(--dp-muted);
-	cursor: pointer;
 	transition: border-color 160ms ease, color 160ms ease, transform 160ms ease, background 160ms ease;
 }
 
@@ -492,7 +515,6 @@ body.command-search-open {
 	background: var(--dp-canvas);
 	color: var(--dp-muted);
 	font: 22px/1 var(--dp-font-ui);
-	cursor: pointer;
 	transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
 }
 
@@ -767,7 +789,6 @@ body.command-search-open {
 	border-radius: 50%;
 	background: var(--dp-paper);
 	color: var(--dp-muted);
-	cursor: pointer;
 	box-shadow: 0 2px 8px color-mix(in srgb, var(--dp-ink) 10%, transparent);
 	transform: translate(50%, -50%);
 	transition: border-color 140ms ease, background 140ms ease, color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
@@ -964,7 +985,6 @@ body.command-search-open {
 	border-radius: 6px;
 	background: transparent;
 	color: var(--dp-muted);
-	cursor: pointer;
 }
 
 .sidebar-search-clear.is-visible {
@@ -1034,7 +1054,6 @@ body.command-search-open {
 	border-radius: 7px;
 	background: transparent;
 	color: var(--dp-muted);
-	cursor: pointer;
 	transition: background 140ms ease, color 140ms ease, transform 140ms ease;
 }
 
@@ -1322,7 +1341,6 @@ body.command-search-open {
 	background: #202633;
 	color: #c6ccda;
 	font: 11px/1.3 var(--dp-font-ui);
-	cursor: pointer;
 	opacity: 0;
 	transition: opacity 140ms ease, background 140ms ease;
 }
@@ -2886,7 +2904,6 @@ body.command-search-open {
 .comment-form .submit,
 .post-password-form input[type="submit"] {
 	min-height: 44px;
-	cursor: pointer;
 }
 
 .alignleft {


### PR DESCRIPTION
## What

The theme has no base cursor layer. `cursor: pointer` is written by hand in eight places in `theme/style.css`, once per control, and anything the author forgets keeps the arrow. Text is worse: without a `body` default, every paragraph, heading and code block hands the reader an I-beam, so a docs page reads like one long text field.

This adds the base layer next to the existing element defaults and drops the per-component declarations it now covers.

```css
a,
button,
summary,
[role="button"],
input[type="button"],
input[type="checkbox"],
input[type="radio"],
input[type="submit"] {
	cursor: pointer;
}

input,
textarea,
[contenteditable="true"] {
	cursor: text;
}
```

`cursor: default` goes into the existing `body` rule, and `touch-action: manipulation` sits next to the `-webkit-tap-highlight-color` rule that is already there. That one kills the 300ms double-tap-zoom delay before a control activates on touch.

`summary` is in the pointer list because raw HTML passes through the Markdown renderer (`src/markdown.js`), so a page author writing `<details><summary>` gets a real disclosure widget in `.entry-content`.

## Removed as redundant

`.header-button, .menu-toggle`, `.command-search-close`, `.sidebar-collapse-toggle`, `.sidebar-search-clear`, `.docs-nav-toggle`, `.copy-code`, and the `cursor` line on `.comment-form .submit, .post-password-form input[type="submit"]`. Each one is a `<button>` in `theme/inc/blocks.php` or `theme/assets/js/docs.js`, so the base rule reaches all of them.

Kept: `.drawer-scrim`, which is a `<div>` the base layer cannot reach, and every `cursor: default` / `not-allowed` state override, including `.docs-nav.is-filtering .docs-nav-toggle`.

## Scope

`theme/style.css` only. I left the eleven `cursor: pointer` declarations in `plugins/docspress-blocks/` alone. DocsPress Blocks ships as its own installable plugin and its stylesheets carry literal fallbacks for every `--dp-*` token, so they are written to survive under another theme. No UA stylesheet gives `<button>` a pointer, so deleting those would regress every copy button and tab the moment the plugin runs without this theme.

`add_editor_style( 'style.css' )` in `theme/functions.php` already loads the theme stylesheet into the editor canvas, so the base layer applies there too.

## A note on checkbox and radio

They are in the pointer list on purpose. Without them, the later `input, textarea` rule would put an I-beam on WordPress core's comment cookie-consent checkbox, which this theme already styles at `.comment-form-cookies-consent label`. The attribute selectors outrank the bare `input`, so the cascade resolves without extra ordering rules.

## Verification

New test in `test/block-theme.test.js` pins the four base rules, asserts the five deduplicated components no longer declare their own pointer, and guards the two intentional exceptions so a later refactor cannot quietly flatten them.

- `npx vitest run test/block-theme.test.js -t "base layer"` fails against unpatched `style.css`, passes with the change.
- `npm test`: 132 passed.
- `npx eslint .`: clean.
