### PR TITLE
Update DocsPress AI skills for current features

### DIFF
--- a/.agents/skills/docspress-install/SKILL.md
+++ b/.agents/skills/docspress-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docspress-install
-description: Install and configure DocsPress for a GitHub repository and its WordPress publishing target. Use when an agent must publish an existing Markdown documentation tree, enable WordPress-to-GitHub proposal pull requests, create or repair the DocsPress GitHub Actions workflow, configure WordPress.com OAuth or an existing bearer-token WordPress endpoint, prepare the companion DocsPress theme and blocks plugin, verify a dry run, or safely move documentation from draft to published pages.
+description: Install and configure DocsPress for a GitHub repository and its WordPress publishing target. Use when an agent must publish an existing or API-versioned Markdown documentation tree, enable WordPress-to-GitHub proposal pull requests, create or repair the DocsPress GitHub Actions workflow, configure WordPress authentication, prepare the companion DocsPress theme and blocks plugin, verify a dry run, or safely move documentation from draft to published Pages.
 ---
 
 # Install DocsPress
@@ -11,7 +11,7 @@ Connect an existing Markdown documentation directory to WordPress without overwr
 
 1. Resolve the repository root, active branch, remote, default branch, and working-tree state.
 2. Find documentation directories and existing workflows. Prefer `rg --files` and inspect `.github/workflows/` before creating files.
-3. Reuse an existing docs directory. Default to `docs/` only when there is no stronger repository convention.
+3. Reuse an existing docs directory. Default to `docs/` only when there is no stronger repository convention. Detect whether it contains multiple maintained API releases, a version registry, version directories, or filename suffixes; do not infer versioning from a changelog alone.
 4. If no usable Markdown documentation exists, invoke `$generate-docs-from-source`, complete its verified docs workflow, then return here.
 5. Inspect an existing DocsPress workflow and update it in place. Never create a second competing sync workflow.
 6. Determine the WordPress target:
@@ -29,6 +29,7 @@ Use these safe defaults unless the repository already defines intentional altern
 | --- | --- |
 | `mode` | `publish` |
 | `docs-dir` | detected docs directory, otherwise `docs` |
+| `versions-file` | empty; versioning stays disabled |
 | `root-slug` | `docs` |
 | `root-title` | `Docs` |
 | `create-h1` | `false` |
@@ -37,9 +38,38 @@ Use these safe defaults unless the repository already defines intentional altern
 | `delete-mode` | `trash` |
 | `dry-run` | `true` |
 
-Use `manifest-file` only when the desired titles, slugs, order, or parent relationships cannot be derived from the directory tree. Use `redirects-file` only when a supplied migration requires old paths to remain discoverable.
+Use `manifest-file` only when the desired titles, slugs, order, or parent relationships cannot be derived from the directory tree. Use `redirects-file` only when a supplied migration requires old paths to remain discoverable. Do not combine either top-level input with `versions-file`; versioned manifests and redirects belong to their owning version entry.
 
 DocsPress manages only pages carrying its sentinel. Treat unmanaged-page conflicts as a stop condition; never delete or overwrite those pages to make a run pass.
+
+### Enable API versioning only when the repository needs it
+
+Without `versions-file`, keep the existing unversioned collection, synchronization, URLs, and reverse pull requests unchanged.
+
+When readers need more than one maintained API release, create or reuse one ordered repository-relative JSON registry:
+
+```json
+{
+  "latest": "v3",
+  "versions": [
+    { "id": "v3", "label": "v3", "source": { "type": "root" } },
+    { "id": "v2", "label": "v2", "source": { "type": "directory", "path": "v2" } },
+    { "id": "v1", "label": "v1", "source": { "type": "suffix", "suffix": ".v1" } }
+  ]
+}
+```
+
+Pass its path as `versions-file`. Preserve the repository’s existing layout: root discovery for the named latest version, a directory below `docs-dir`, a filename suffix before `.md`, or a repository-relative per-version manifest. A version entry may also own a redirects file.
+
+Validate the registry with the collector from the pinned DocsPress revision:
+
+- IDs are unique lowercase URL-safe slugs and `latest` names one configured entry.
+- A root source, when present, is the repository latest; it excludes files claimed by other sources.
+- Every Markdown file has one source owner, every path stays within its allowed root, and normalized logical routes are unique within a version.
+- Directory, suffix, manifest, and redirect paths exist and do not escape the repository.
+- Relative links resolve inside the source version; a same-route file in another version is never a substitute.
+
+Versioning requires the matching DocsPress Blocks plugin. Synchronization creates the `docspress_version` Page taxonomy, preserves exact source paths and logical routes as managed metadata, and keeps one active term as the effective latest. The repository latest is the default; a valid active override under **Settings → DocsPress** changes public routing without renaming Pages.
 
 ## 3. Create or repair the GitHub Actions workflow
 
@@ -66,6 +96,7 @@ jobs:
           wordpress-site: example.wordpress.com
           wordpress-access-token: ${{ secrets.WP_ACCESS_TOKEN }}
           docs-dir: docs
+          # versions-file: docs-versions.json
           root-slug: docs
           root-title: Docs
           create-h1: false
@@ -97,7 +128,7 @@ concurrency:
   cancel-in-progress: false
 ```
 
-Set `mode: reconcile` on the pinned DocsPress step. Confirm the repository permits GitHub Actions to create pull requests, or use an approved GitHub App/PAT through `github-token`. Explain that the WordPress token still accesses only WordPress; the GitHub token maintains the action-owned `docspress/wordpress-sync` branch and rolling pull request. Enabling this mode authorizes ongoing WordPress metadata writes and GitHub branch/PR writes, so obtain explicit approval for both boundaries.
+Set `mode: reconcile` on the pinned DocsPress step. Confirm the repository permits GitHub Actions to create pull requests, or use an approved GitHub App/PAT through `github-token`. Explain that the WordPress token still accesses only WordPress; the GitHub token maintains the action-owned `docspress/wordpress-sync` branch and rolling pull request. With versioning, WordPress edits return to the exact root-, directory-, suffix-, or manifest-owned paths stored on each Page. The generated pull request title and body group changes by version unless `pull-request-title` explicitly overrides the title. Enabling this mode authorizes ongoing WordPress metadata writes and GitHub branch/PR writes, so obtain explicit approval for both boundaries.
 
 Do not invent a release tag or copy an unverified SHA. If an immutable revision cannot be verified, stop and ask before using a floating ref such as `@main`.
 
@@ -136,7 +167,7 @@ gh secret list --repo OWNER/REPO
 
 ## 5. Prepare the WordPress presentation layer
 
-The REST sync works without the companion theme or blocks plugin. Install them when the user wants the full DocsPress reading experience.
+Unversioned REST sync works without the companion theme or blocks plugin. Install them when the user wants the full DocsPress reading experience. The matching DocsPress Blocks plugin is mandatory when `versions-file` is enabled.
 
 1. Package `theme/` as a WordPress theme directory named `docspress/` with `style.css` at its root, using only a verified official DocsPress checkout and revision.
 2. Package `plugins/docspress-blocks/` with `docspress-blocks.php` at its root from that same verified revision.
@@ -150,11 +181,22 @@ wp plugin install /absolute/path/docspress-blocks.zip --activate
 
 Installing or activating a plugin and activating a theme change WordPress state. Request separate approval before plugin installation/activation and before running `wp theme activate docspress` or performing the equivalent Admin action.
 
-After the first sync, select the generated Docs Page under **Appearance → Customize → DocsPress Theme → Navigation → Documentation root**. Keep `create-h1: false` because the theme renders the Page title.
+After the first sync, open **Appearance → Editor**. Set the documentation root on the Docs Navigation block in the Page template and keep `create-h1: false` because the theme renders the Page title.
+
+The bundled block theme supplies:
+
+- a customizable Header with the Version Switcher dropdown immediately before Command Search;
+- a full-width, customizable Version Notice below the Header on historical Pages;
+- clean effective-latest routes, historical version prefixes, version-aware search/navigation/breadcrumbs/sitemaps, exact `.md` routes, and `llms.txt`;
+- a Pages screen with version filtering, Latest/Inactive badges, and clickable GitHub source paths for managed docs;
+- a movable **Was This Helpful?** template block with per-Page aggregate results in the editor;
+- optional native threaded comments through the editable Comments template part.
+
+Keep these as Site Editor blocks and template parts so the active style family and Global Styles control colors, gradients, typography, spacing, borders, dimensions, positioning, shadows, anchors, and custom classes. Do not hard-code presentation into synchronized Markdown.
 
 ## 6. Verify in increasing-risk order
 
-1. Confirm every workflow path and optional manifest/redirect file exists.
+1. Confirm every workflow path and optional manifest, redirect, and version-registry file exists.
 2. Validate YAML with an available YAML parser or `actionlint` when installed.
 3. Run repository tests, lint, build, and `git diff --check` when those commands exist.
 4. Confirm `WP_ACCESS_TOKEN` appears in `gh secret list` without reading its value.
@@ -162,7 +204,7 @@ After the first sync, select the generated Docs Page under **Appearance → Cust
 6. Dispatch the manual workflow only after approval with `dry-run: true`; inspect the Actions summary and `summary-json`.
 7. Stop on unmanaged conflicts, authentication errors, unexpected deletes, or an incorrect page tree.
 8. Explain that `delete-mode: trash` is a Page mutation once dry-run is disabled. After explicit approval for Page creation, updates, and trash operations, change only `dry-run` to `false` and keep `status: draft`.
-9. Inspect the generated WordPress hierarchy, blocks, rewritten links, and edit links.
+9. Inspect the generated WordPress hierarchy, blocks, rewritten links, exact GitHub paths, and edit links. For versioning, also verify taxonomy terms, latest state, Pages filters, clean/latest and historical routes, switcher counterparts, missing-page fallback, `.md`, `llms.txt`, and reverse-sync destinations.
 10. Changing dry-run to false creates an ongoing write-capable workflow. Obtain explicit approval before committing that state. Add an automatic default-branch `push` trigger only after the manual lifecycle succeeds and the user approves ongoing synchronization.
 11. Change `status` to `publish` only after the user approves public publication.
 
@@ -171,9 +213,10 @@ After the first sync, select the generated Docs Page under **Appearance → Cust
 Report:
 
 - docs directory and root URL;
+- versioning state, registry path, repository latest, and effective latest;
 - workflow path and trigger branch;
 - WordPress mode and site, without secrets;
-- companion theme/plugin installation state;
+- companion theme/plugin installation state and Site Editor components enabled;
 - verification commands and results;
 - current safety state: dry-run, draft, or published;
 - remaining user action, such as creating OAuth credentials, adding the secret, approving activation, pushing, or publishing.

--- a/.agents/skills/docspress-install/agents/openai.yaml
+++ b/.agents/skills/docspress-install/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Install DocsPress"
-  short_description: "Connect GitHub docs to WordPress safely"
-  default_prompt: "Use $docspress-install to publish this repository documentation to WordPress."
+  short_description: "Publish and version GitHub docs safely"
+  default_prompt: "Use $docspress-install to inspect this repository, preserve its documentation layout, and configure a safe DocsPress publication with API versioning when the source requires it."

--- a/.agents/skills/generate-docs-from-source/SKILL.md
+++ b/.agents/skills/generate-docs-from-source/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generate-docs-from-source
-description: Generate accurate DocsPress-compatible Markdown documentation from an existing source-code repository, select and serialize the available DocsPress Gutenberg blocks correctly, verify examples and claims against code and tests, create or improve the docs/ hierarchy, and configure a safe DocsPress GitHub Actions workflow when one is missing. Use when a project has incomplete, stale, or no documentation and an agent must derive installation, configuration, guides, API or CLI references, architecture, and troubleshooting material from the repository itself before publishing to WordPress.
+description: Generate accurate DocsPress-compatible Markdown documentation from an existing source-code repository, including maintained API versions when required. Use when a project has incomplete, stale, or no documentation and an agent must derive installation, configuration, guides, API or CLI references, architecture, troubleshooting, DocsPress Gutenberg blocks, and a safe publication workflow from code and tests.
 ---
 
 # Generate Docs from Source
@@ -12,14 +12,15 @@ Build documentation from evidence in the repository, not assumptions. Produce a 
 1. Resolve the repository root and preserve unrelated working-tree changes.
 2. Inventory the project with `rg --files`. Inspect package manifests, lockfiles, entrypoints, exports, command definitions, schemas, environment examples, tests, examples, release configuration, and existing docs.
 3. Identify the intended audience and supported public surface from repository evidence.
-4. Build an internal coverage map before writing:
+4. Determine whether the project currently supports multiple API releases. Require explicit evidence such as maintained release branches, versioned schemas, compatibility tests, or existing versioned docs; do not treat package history as a reason to publish old documentation.
+5. Build an internal coverage map before writing:
    - installation commands → package manifests and lockfiles;
    - configuration and environment variables → schemas, defaults, and code reads;
    - API signatures → exported source and type declarations;
    - CLI commands and flags → parser definitions and help output;
    - behavior and edge cases → tests;
    - operational steps → scripts and CI workflows.
-5. Treat tests and executable examples as stronger evidence than comments. Mark contradictions for resolution instead of choosing silently.
+6. Treat tests and executable examples as stronger evidence than comments. Mark contradictions for resolution instead of choosing silently.
 
 Do not document private helpers as public APIs. Do not invent commands, options, URLs, support guarantees, performance claims, or output text.
 
@@ -50,6 +51,23 @@ Create only pages supported by the source. Small libraries may need only an over
 
 Map `docs/index.md` to the Docs root. Use folder `index.md` files for section landing pages. Avoid multiple files that normalize to the same route.
 
+### Plan maintained API versions
+
+Keep a single unversioned tree unless readers genuinely need multiple maintained API contracts. When they do, preserve the repository’s natural layout and add an ordered registry such as `docs-versions.json`:
+
+```json
+{
+  "latest": "v3",
+  "versions": [
+    { "id": "v3", "source": { "type": "root" } },
+    { "id": "v2", "source": { "type": "directory", "path": "v2" } },
+    { "id": "v1", "source": { "type": "suffix", "suffix": ".v1" } }
+  ]
+}
+```
+
+The named latest can own unclaimed Markdown at the root. Other versions may use directories, filename suffixes, or repository-relative manifests with their own redirects. Give every source file exactly one owner and every version a unique logical route per Page. Link counterparts within the same version. When a Page does not exist in another version, let the Version Switcher fall back to that version’s root rather than inventing a counterpart.
+
 ## 3. Write DocsPress-compatible Markdown
 
 Use this page pattern:
@@ -73,6 +91,7 @@ Follow these constraints:
 - Keep paths stable and slugs readable; directories become parent Pages.
 - Use fenced code blocks with accurate language labels.
 - Use standard Markdown for ordinary prose, headings, lists, links, tables, and images. Use the DocsPress blocks below whenever their documentation-specific semantics apply.
+- Use a serialized `core/image` block when an image needs Gutenberg-managed width, size, caption, or link behavior; keep ordinary Markdown image syntax for unconstrained images.
 - Preserve existing serialized Gutenberg block comments when valid. Validate their attributes before reusing them.
 - Prefer `docspress/code-tabs` over Gutenberg Handbook-style `{% codetabs %}` when the DocsPress Blocks plugin is part of the target installation.
 - Explain prerequisites before commands and verification after commands.
@@ -81,7 +100,7 @@ Follow these constraints:
 
 ## 4. Use DocsPress Gutenberg blocks
 
-Always review all thirteen documentation blocks before writing the docs and make a page-by-page block plan. Use every relevant block, but do not force a block where ordinary Markdown communicates the material better.
+Always review the complete plugin catalog—two landing blocks, thirteen documentation blocks, and two version-interface blocks—before writing the docs and make a page-by-page block plan. Use every relevant block, but do not force a block where ordinary Markdown communicates the material better.
 
 DocsPress preserves serialized Gutenberg comments in Markdown and normalizes HTML-sensitive attribute characters to WordPress-safe Unicode escapes during conversion. These plugin blocks are dynamic, so write one self-closing comment with valid compact JSON and no rendered HTML body:
 
@@ -95,6 +114,8 @@ In generated Markdown, emit the comment directly, without the surrounding code f
 
 | Editor block | Serialized name | Use for | Supported attributes |
 | --- | --- | --- | --- |
+| DocsPress: Hero | `docspress/hero` | A landing-page introduction with actions and an image or built-in synchronization diagram | `eyebrow`, `title`, `description`, `primaryLabel`, `primaryUrl`, `primaryNewTab`, `secondaryLabel`, `secondaryUrl`, `secondaryNewTab`, `mediaId`, `mediaUrl`, `mediaAlt`, `visualLabel`, `visualVariant`, `layout`, `mediaPosition`, `mediaWidth`, `imageScale`, `height`, `tone`, `textAlign`, `showGrid`, `showOrbit`, `panelColor`, `visualColor`, `accentColor` |
+| DocsPress: Audience Paths | `docspress/audience-paths` | One to six cards routing distinct reader audiences to the right workflow | `eyebrow`, `title`, `description`, `paths`, `columns`, `tone`, `textAlign`, `compact`, `showNumbers`, `panelColor`, `accentColor`; each path has `title`, `description`, `url`, `cta`, `icon`, `accent`, `newTab` |
 | DocsPress: Colorful Code | `docspress/colorful-code` | One source, annotated example, or unified diff that benefits from filename, highlighting, line numbers, caption, and copy | `language`, `filename`, `code`, `highlightedLines`, `showLineNumbers`, `caption`, `diffMode`, `copyMode`, `annotations`; each annotation has `line`, `content` |
 | DocsPress: Code Tabs | `docspress/code-tabs` | Two to eight equivalent implementations, package managers, languages, or platforms | `tabs`, `showLineNumbers`, `caption`; each tab has `label`, `language`, `filename`, `code` |
 | DocsPress: Callout | `docspress/callout` | Important notes, tips, warnings, hazards, or success guidance | `tone`, `title`, `content`, `collapsible`, `open` |
@@ -108,6 +129,8 @@ In generated Markdown, emit the comment directly, without the surrounding code f
 | DocsPress: Result | `docspress/result` | A concise verified outcome after a build, check, command, or procedure | `status`, `title`, `content`, `meta` |
 | DocsPress: File Tree | `docspress/file-tree` | A relevant project or generated-directory structure | `root`, `tree`, `caption` |
 | DocsPress: Prompt | `docspress/prompt` | A reusable AI prompt with model, mode, context, and caption | `prompt`, `model`, `mode`, `thinking`, `context`, `caption` |
+| DocsPress: Version Switcher | `docspress/version-switcher` | Switching API versions by logical route; normally place in a Site Editor template rather than Page Markdown | `label`, `showLabel`, `presentation`, `showLatestBadge`, `hideSingle`, `unavailableLabel` |
+| DocsPress: Version Notice | `docspress/version-notice` | Warning only on historical API versions; normally place below the Header in the Page template | `message`, `latestLinkLabel`, `showIcon`, `dismissible` |
 
 Use only these allowed values:
 
@@ -123,10 +146,17 @@ Use only these allowed values:
 - Result `status`: `success`, `neutral`, `warning`, or `error`.
 - Prompt `mode`: `chat`, `code`, `ask`, or `plan`. `context` is a comma-separated list of at most 12 items; `$` denotes an installed skill, `@` a mention, `#` an image, `http://` or `https://` a URL, and other values a file. Always invoke installed skills as `$skill-name`, never as a `SKILL.md` file path inside a user-facing prompt.
 - File trees use two spaces per depth level and a trailing slash for folders.
+- Hero `visualVariant`: `image` or `sync-diagram`; `layout`: `split` or `editorial`; `mediaPosition`: `left` or `right`; `height`: `compact`, `standard`, or `tall`; `tone`: `theme`, `midnight`, `paper`, or `brand`; `textAlign`: `left` or `center`. Keep media width at 34–58 and image scale at 60–120.
+- Audience Paths `columns`: 1–3; `tone`: `theme`, `paper`, `ink`, or `blueprint`; `textAlign`: `left` or `center`; path `accent`: `blue`, `gold`, `coral`, or `green`.
+- Version Switcher `presentation`: `select` or `links`. Version Notice `message` may contain only the safe `{current}` and `{latest}` placeholders.
 
 ### Canonical examples
 
 ```html
+<!-- wp:docspress/hero {"eyebrow":"Developer documentation","title":"Build your first integration","description":"Choose a verified workflow and ship a working request.","primaryLabel":"Get started","primaryUrl":"/docs/getting-started/","primaryNewTab":false,"secondaryLabel":"API reference","secondaryUrl":"/docs/reference/api/","secondaryNewTab":false,"visualVariant":"sync-diagram","layout":"split","mediaPosition":"right","mediaWidth":44,"imageScale":100,"height":"standard","tone":"theme","textAlign":"left","showGrid":false,"showOrbit":false} /-->
+
+<!-- wp:docspress/audience-paths {"eyebrow":"Choose a path","title":"What are you building?","description":"Start with the workflow that matches your integration.","paths":[{"title":"Server integration","description":"Authenticate and call the API from a trusted backend.","url":"/docs/guides/server/","cta":"Build on the server","icon":"api","accent":"blue","newTab":false},{"title":"Browser application","description":"Use the supported public client flow.","url":"/docs/guides/browser/","cta":"Build for the browser","icon":"code","accent":"gold","newTab":false}],"columns":2,"tone":"theme","textAlign":"left","compact":false,"showNumbers":false} /-->
+
 <!-- wp:docspress/colorful-code {"language":"typescript","filename":"src/client.ts","code":"import { Client } from \"pkg\";\n\nconst client = new Client();","highlightedLines":"3","showLineNumbers":true,"caption":"Create the client."} /-->
 
 <!-- wp:docspress/code-tabs {"tabs":[{"label":"npm","language":"bash","filename":"Terminal","code":"npm install example"},{"label":"pnpm","language":"bash","filename":"Terminal","code":"pnpm add example"}],"showLineNumbers":false,"caption":"Install with the package manager used by the project."} /-->
@@ -158,6 +188,12 @@ Use verified source values in real docs instead of copying these placeholders. K
 
 This catalog matches the DocsPress Blocks source shipped with the skill revision. If a verified target plugin revision differs, inspect its `blocks/*/block.php` registrations and render allow-lists, then use that revision as the source of truth.
 
+### Keep template-owned features out of ordinary Page content
+
+Use the Site Editor for shared reading-interface blocks. The bundled Header places Version Switcher before Command Search, and the Page template places Version Notice as a full-width bar below the Header. The theme also owns `docspress/was-this-helpful`, which is movable and customizable in the Page template and stores aggregate Helpful/Not helpful totals per Page. Native WordPress comments provide optional threaded discussions through the editable Comments template part.
+
+Do not duplicate these blocks into every Markdown Page. Do not serialize `docspress/was-this-helpful` unless the target uses the DocsPress theme revision that registers it. Keep presentation under Global Styles and block supports instead of adding custom colors to generated content.
+
 ## 5. Generate from evidence
 
 ### Overview and getting started
@@ -186,14 +222,15 @@ Run the cheapest relevant checks first and record exact results.
 
 1. Confirm every generated page is nonempty and has a unique route and title.
 2. Resolve every relative link and local image path from the file containing it.
-3. Search for placeholders such as `TODO`, `TBD`, `YOUR_*`, fake domains, and unverified version numbers. Keep deliberate placeholders only inside clearly labeled templates.
-4. Match documented exports, flags, environment variables, filenames, and defaults back to source.
-5. Run code samples when they are safe and practical. Prefer examples already covered by tests.
-6. Parse every `wp:docspress/*` attribute object as JSON. Confirm the block name, attributes, enum values, tab count, tree indentation, and required plugin support against this catalog or the verified plugin source.
-7. Run representative generated Markdown through the pinned DocsPress converter and confirm every custom block comment is preserved byte-for-byte.
-8. Inspect repository scripts and dependency lifecycle hooks before executing them. Run the existing formatter, lint, typecheck, tests, and build in proportion to the changes; isolate commands that rewrite generated files in a temporary copy or worktree when practical.
-9. Run `git diff --check` and inspect the complete docs diff for accidental source changes or copied secrets.
-10. If a check cannot run, state why and narrow the claim. Never present an unrun example as verified.
+3. For a version registry, run the pinned DocsPress collector and verify source ownership, safe paths, unique logical routes, latest ownership, per-version redirects, and version-aware links.
+4. Search for placeholders such as `TODO`, `TBD`, `YOUR_*`, fake domains, and unverified version numbers. Keep deliberate placeholders only inside clearly labeled templates.
+5. Match documented exports, flags, environment variables, filenames, and defaults back to source.
+6. Run code samples when they are safe and practical. Prefer examples already covered by tests.
+7. Parse every `wp:docspress/*` attribute object as JSON. Confirm the block name, attributes, enum values, tab count, tree indentation, and required plugin support against this catalog or the verified plugin source.
+8. Run representative generated Markdown through the pinned DocsPress converter and confirm every custom block comment is preserved byte-for-byte.
+9. Inspect repository scripts and dependency lifecycle hooks before executing them. Run the existing formatter, lint, typecheck, tests, and build in proportion to the changes; isolate commands that rewrite generated files in a temporary copy or worktree when practical.
+10. Run `git diff --check` and inspect the complete docs diff for accidental source changes or copied secrets.
+11. If a check cannot run, state why and narrow the claim. Never present an unrun example as verified.
 
 Do not weaken tests or alter product behavior merely to make documentation examples pass. If source behavior is broken or ambiguous, report it separately.
 
@@ -208,7 +245,8 @@ Search `.github/workflows/` for an existing DocsPress action. If none exists:
 5. Resolve checkout and DocsPress actions to verified immutable commit SHAs, then validate all inputs against `action.yml` at the pinned DocsPress revision.
 6. Detect the repository default branch rather than hard-coding `main`, but begin with `workflow_dispatch` only. Add a default-branch push trigger after the manual dry-run and draft-write lifecycle succeeds and the user approves ongoing synchronization.
 7. If any `wp:docspress/*` blocks are present, require the verified matching `plugins/docspress-blocks/` plugin on the WordPress target. Ask separately before installing or activating it.
-8. Validate the workflow locally. Do not push, dispatch, add secrets, install or activate plugins, activate a theme, or write WordPress Pages unless the user separately authorized those external changes.
+8. When a registry exists, pass it as `versions-file`, include it in workflow path filters, and require the matching DocsPress Blocks plugin even when Page bodies use no plugin blocks.
+9. Validate the workflow locally. Do not push, dispatch, add secrets, install or activate plugins, activate a theme, or write WordPress Pages unless the user separately authorized those external changes.
 
 Documentation generation must still complete when WordPress credentials are unavailable. Leave the workflow ready and report the exact authentication step the user must perform.
 
@@ -220,6 +258,7 @@ Report:
 - source files used as evidence;
 - code examples and commands actually executed;
 - DocsPress blocks used, their locations, serialization validation, and plugin requirement;
+- version registry, source layouts, repository latest, logical-route validation, and intentionally missing counterparts;
 - lint, test, build, link, and workflow validation results;
 - DocsPress workflow state;
 - any unverified claims, source contradictions, or required user decisions.

--- a/.agents/skills/generate-docs-from-source/agents/openai.yaml
+++ b/.agents/skills/generate-docs-from-source/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Generate Docs from Source"
-  short_description: "Build verified docs with DocsPress blocks"
-  default_prompt: "Use $generate-docs-from-source to inspect this repository, generate verified documentation with the appropriate DocsPress Gutenberg blocks, and configure DocsPress."
+  short_description: "Build verified, version-aware DocsPress docs"
+  default_prompt: "Use $generate-docs-from-source to inspect this repository, generate verified documentation with the current DocsPress blocks, and preserve maintained API versions when the source proves they are needed."


### PR DESCRIPTION
## What changed

- teach `docspress-install` the opt-in `versions-file` registry, mixed root/directory/suffix/manifest layouts, taxonomy/latest behavior, exact reverse-sync paths, and version-aware WordPress verification
- update `generate-docs-from-source` for the full 17-block plugin catalog, maintained API-version planning, constrained Gutenberg images, version interface placement, and theme-owned feedback/discussion features
- replace obsolete Customizer guidance with the Site Editor workflow
- refresh both OpenAI interface metadata files and starter prompts

## Why

The repository skills predated API versioning and several newer plugin/theme capabilities. Agents could therefore omit current setup requirements or describe an incomplete block catalog.

## Impact

Agents installing DocsPress or generating docs from source can now preserve versioned source layouts, configure the matching WordPress features, and use the current Gutenberg and theme surfaces without enabling versioning for ordinary single-tree documentation.

## Validation

- both skills passed `quick_validate.py`
- both `agents/openai.yaml` files parsed successfully
- 16 serialized DocsPress block examples parsed as JSON
- `npm run lint`
- `npm test` — 149 tests passed
- `git diff --check`