### PR TITLE
Use canonical docs.press site identifier

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -39,7 +39,7 @@ jobs:
           # WP_ACCESS_TOKEN is a WordPress.com OAuth token. Send it through the
           # WordPress.com API so the request receives its authenticated user.
           wordpress-url: https://public-api.wordpress.com
-          wordpress-site: fkadocs.atomicsites.blog
+          wordpress-site: docs.press
           wordpress-access-token: ${{ secrets.WP_ACCESS_TOKEN }}
           docs-dir: docs
           root-slug: docs


### PR DESCRIPTION
## What changed

Uses `docs.press` as the WordPress.com site identifier for the production documentation sync.

## Why

The first authenticated-endpoint recovery run proved that `fkadocs.atomicsites.blog` is no longer a registered WordPress.com API site alias and fails with `invalid_site`. The custom domain is the canonical identifier; OAuth authentication supplies access to its otherwise disabled public API.

## Validation

- confirmed `fkadocs.atomicsites.blog` returns `unknown_blog` / `invalid_site`
- confirmed `docs.press` resolves as a WordPress.com site whose API requires authentication
- `git diff --check`