### PR TITLE
Restore the Atomic docs sync target

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -36,10 +36,8 @@ jobs:
       - uses: ./
         with:
           mode: reconcile
-          # WP_ACCESS_TOKEN is a WordPress.com OAuth token. Send it through the
-          # WordPress.com API so the request receives its authenticated user.
-          wordpress-url: https://public-api.wordpress.com
-          wordpress-site: docs.press
+          wordpress-url: https://fkadocs.atomicsites.blog
+          wordpress-site: fkadocs.atomicsites.blog
           wordpress-access-token: ${{ secrets.WP_ACCESS_TOKEN }}
           docs-dir: docs
           root-slug: docs


### PR DESCRIPTION
## What changed

Restores the production DocsPress workflow to the direct Atomic site endpoint at `fkadocs.atomicsites.blog`.

## Root cause

`docs.press` resolves through the WordPress.com API to the unrelated legacy `fkadev.blog` site. The actual docs.press install is an independent Atomic WordPress site with 46 published Pages and must use its direct `/wp-json` endpoint plus a site-issued bearer credential.

The workflow is manually disabled while that direct credential is replaced, so scheduled reconciliation cannot write to either site.

## Validation

- confirmed `https://docs.press/wp-json` reports the live DocsPress site
- confirmed its public Pages collection contains 46 published Pages
- confirmed the WordPress.com alias returns `fkadev.blog` Pages instead
- confirmed the current local WordPress.com token cannot edit the Atomic site
- `git diff --check`