### PR TITLE
Use canonical origin for Atomic sync

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -36,8 +36,10 @@ jobs:
       - uses: ./
         with:
           mode: reconcile
-          wordpress-url: https://fkadocs.atomicsites.blog
-          wordpress-site: fkadocs.atomicsites.blog
+          # Use the canonical origin so Fetch preserves the Authorization
+          # header instead of following a cross-origin Atomic-domain redirect.
+          wordpress-url: https://docs.press
+          wordpress-site: docs.press
           wordpress-access-token: ${{ secrets.WP_ACCESS_TOKEN }}
           docs-dir: docs
           root-slug: docs

--- a/test/workflow.test.js
+++ b/test/workflow.test.js
@@ -1,0 +1,13 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("production documentation workflow", () => {
+  it("uses the canonical docs.press REST origin so authentication survives the request", async () => {
+    const workflow = await fs.readFile(".github/workflows/sync-docs.yml", "utf8");
+
+    expect(workflow).toContain("wordpress-url: https://docs.press");
+    expect(workflow).toContain("wordpress-site: docs.press");
+    expect(workflow).not.toContain("fkadocs.atomicsites.blog");
+    expect(workflow).toContain("wordpress-access-token: ${{ secrets.WP_ACCESS_TOKEN }}");
+  });
+});


### PR DESCRIPTION
## What changed

- Point the production documentation workflow at the canonical `https://docs.press` REST origin.
- Keep the direct Atomic bearer-token flow and dedicated `docspress-sync` user.
- Add a regression test that rejects the redirecting `fkadocs.atomicsites.blog` origin.

## Root cause

`fkadocs.atomicsites.blog` returns a cross-origin redirect to `docs.press`. Fetch does not forward the Authorization header to the new origin, so WordPress handled the redirected Pages request as anonymous and returned `rest_cannot_edit`.

## Validation

- Rotated the dedicated `dpa_…` token; its hash is stored on WordPress and the value is stored only as the Actions secret.
- Verified the token directly against `https://docs.press/wp-json/wp/v2/pages?context=edit&status=publish&per_page=1` with HTTP 200.
- `npm run lint`
- 14 test files and 285 tests passed
- `git diff --check`
