### PR TITLE
Document self-hosted WordPress authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Quick start
 
 1. Put the Markdown documentation in `docs/`.
-2. [Create a WordPress.com token](#wordpresscom-authentication).
+2. [Create a WordPress access token](#authentication).
 3. Add one of the [GitHub Actions workflows](#github-actions) below.
 4. Run it first with `status: draft` and `dry-run: true`.
 
@@ -131,7 +131,9 @@ jobs:
 
 WordPress-only edits become a rolling Markdown pull request. A true two-sided edit is reported as a conflict instead of overwriting either version.
 
-## WordPress.com authentication
+## Authentication
+
+### WordPress.com
 
 DocsPress uses a WordPress.com OAuth token stored as the repository secret `WP_ACCESS_TOKEN`.
 
@@ -159,7 +161,32 @@ The helper opens WordPress.com for authorization and stores the resulting token 
 gh secret list --repo OWNER/REPO
 ```
 
-For the full OAuth explanation, use [Authenticate WordPress](https://docs.press/docs/publish-existing-docs/authentication/).
+### Self-hosted WordPress (.org)
+
+DocsPress can use a REST API key from your host or authentication plugin when it accepts `Authorization: Bearer …`. Core WordPress does not create this key itself.
+
+Store the key without printing it:
+
+```bash
+printf "WordPress REST API key: "
+IFS= read -r -s WORDPRESS_REST_API_KEY
+printf "\n"
+printf "%s" "$WORDPRESS_REST_API_KEY" |
+  gh secret set WP_ACCESS_TOKEN --repo OWNER/REPO
+unset WORDPRESS_REST_API_KEY
+```
+
+Set `wordpress-url` to the site origin without `/wp-json`:
+
+```yaml
+wordpress-url: https://docs.example.com
+wordpress-site: docs.example.com
+wordpress-access-token: ${{ secrets.WP_ACCESS_TOKEN }}
+```
+
+DocsPress calls `https://docs.example.com/wp-json/wp/v2/pages`. Confirm that the key can read, create, update, and delete Pages before publishing.
+
+For the complete setup, use [Authenticate WordPress](https://docs.press/docs/publish-existing-docs/authentication/).
 
 ## Documentation
 

--- a/test/block-theme.test.js
+++ b/test/block-theme.test.js
@@ -229,7 +229,10 @@ describe("DocsPress block theme constraints", () => {
     expect(readme).toContain("blueprint-versioning.json");
     expect(readme).toContain("## GitHub Actions");
     expect(readme).toContain("mode: reconcile");
-    expect(readme).toContain("## WordPress.com authentication");
+    expect(readme).toContain("## Authentication");
+    expect(readme).toContain("### WordPress.com");
+    expect(readme).toContain("### Self-hosted WordPress (.org)");
+    expect(readme).toContain("wordpress-url: https://docs.example.com");
     expect(readme).toContain("https://docs.press/docs/");
     expect(readme).not.toContain("## Configuration");
   });


### PR DESCRIPTION
## What changed

- Make the quick-start authentication link cover both hosted and self-hosted WordPress.
- Keep the WordPress.com OAuth helper instructions.
- Add a concise WordPress.org/self-hosted REST API key flow.
- Show the required `wordpress-url`, `wordpress-site`, and secret inputs.
- Extend the README contract test for both authentication paths.

## Important compatibility note

DocsPress currently sends `Authorization: Bearer …`. The README therefore explains that a self-hosted REST API key must come from a host or authentication plugin that accepts Bearer tokens; core WordPress does not issue this key itself.

## Validation

- `npm test` — 14 files, 285 tests
- `npm run lint`
- All three embedded YAML examples parse successfully.
